### PR TITLE
M0-01: freeze research protocol and schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Warnings are treated as errors except for missing XML documentation (`CS1591`),
 which remains visible as the temporary M0-00 migration baseline. All other
 compiler, analyzer, and style diagnostics fail the build.
 
+## Research Protocol
+
+The versioned experiment and lexicon interchange contracts live under
+`experiments/schemas/` and `resources/lexicons/schemas/`. See the
+[frozen research protocol](experiments/protocol.md) for field definitions,
+inclusion and exclusion rules, planned contrasts, and the confirmatory decision
+rule. Schema conformance is enforced by the unit-test suite.
+
 ## Introduction
 
 The initial goal is to investigate whether a particular theory of a possible

--- a/experiments/confirmatory.protocol.json
+++ b/experiments/confirmatory.protocol.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "schemas/experiment.schema.json",
+  "schema_version": "1.0.0",
+  "experiment_id": "confirmatory-voynich-language-panel",
+  "phase": "confirmatory",
+  "frozen": true,
+  "corpus_split": {
+    "selection_basis": "predeclared_loci",
+    "selection_uses_comparative_scores": false,
+    "evaluation_partition": {
+      "id": "confirmatory-evaluation",
+      "loci": ["f1r", "f1v", "f2r", "f2v"]
+    },
+    "holdout_partition": {
+      "id": "confirmatory-holdout",
+      "loci": ["f3r", "f3v", "f4r", "f4v"]
+    }
+  },
+  "transcription": { "id": "takeshi-takahashi-eva", "version": "1.6e6" },
+  "mapping": { "id": "enochian-eva-to-ipa", "version": "1.0.0" },
+  "tokenization": {
+    "method": "eva-whitespace-words",
+    "version": "1.0.0",
+    "unicode_normalization": "NFC",
+    "uncertain_tokens": "exclude"
+  },
+  "feature_set": { "id": "enochian-phonological-features", "version": "1.0.0" },
+  "dtw": {
+    "distance_metric": "euclidean",
+    "normalization": "path_length",
+    "window": null,
+    "mapping_selection": "predeclared_single"
+  },
+  "length_filters": { "minimum_phonemes": 3, "maximum_phonemes": 20 },
+  "lexicon_filters": {
+    "entry_kinds": ["lemma"],
+    "parts_of_speech": [],
+    "duplicate_forms": "deduplicate_within_source",
+    "proper_names": "exclude",
+    "abbreviations": "exclude",
+    "inflected_forms": "exclude"
+  },
+  "randomization": {
+    "seeds": { "sampling": 15485863, "null_generation": 15485867, "permutation": 15485917 },
+    "sample_count": 10000,
+    "permutation_count": 100000
+  },
+  "planned_contrasts": [
+    {
+      "id": "indo-aryan-vs-controls",
+      "primary": true,
+      "target_groups": ["Indo-Aryan"],
+      "control_groups": ["non-Indo-Aryan controls"],
+      "expected_direction": "lower"
+    },
+    {
+      "id": "romani-vs-non-indo-aryan-controls",
+      "primary": false,
+      "target_groups": ["Romani"],
+      "control_groups": ["non-Indo-Aryan controls"],
+      "expected_direction": "lower"
+    }
+  ],
+  "statistics": {
+    "primary_statistic": "mean_normalized_dtw_difference",
+    "correction_method": "holm",
+    "alpha": 0.05,
+    "confidence_level": 0.95
+  },
+  "outputs": {
+    "root_directory": "outputs/confirmatory",
+    "scores": "scores.jsonl",
+    "quality_report": "quality-report.json",
+    "metadata": "metadata.json"
+  }
+}

--- a/experiments/exploratory.example.json
+++ b/experiments/exploratory.example.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "schemas/experiment.schema.json",
+  "schema_version": "1.0.0",
+  "experiment_id": "exploratory-voynich-language-panel",
+  "phase": "exploratory",
+  "frozen": false,
+  "corpus_split": {
+    "selection_basis": "predeclared_loci",
+    "selection_uses_comparative_scores": false,
+    "evaluation_partition": {
+      "id": "exploratory-evaluation",
+      "loci": ["f1r", "f1v"]
+    },
+    "holdout_partition": {
+      "id": "exploratory-holdout",
+      "loci": ["f2r", "f2v"]
+    }
+  },
+  "transcription": { "id": "takeshi-takahashi-eva", "version": "1.6e6" },
+  "mapping": { "id": "enochian-eva-to-ipa", "version": "1.0.0" },
+  "tokenization": {
+    "method": "eva-whitespace-words",
+    "version": "1.0.0",
+    "unicode_normalization": "NFC",
+    "uncertain_tokens": "exclude"
+  },
+  "feature_set": { "id": "enochian-phonological-features", "version": "1.0.0" },
+  "dtw": {
+    "distance_metric": "euclidean",
+    "normalization": "path_length",
+    "window": null,
+    "mapping_selection": "predeclared_sensitivity_set"
+  },
+  "length_filters": { "minimum_phonemes": 3, "maximum_phonemes": 20 },
+  "lexicon_filters": {
+    "entry_kinds": ["lemma"],
+    "parts_of_speech": [],
+    "duplicate_forms": "deduplicate_within_source",
+    "proper_names": "exclude",
+    "abbreviations": "exclude",
+    "inflected_forms": "exclude"
+  },
+  "randomization": {
+    "seeds": { "sampling": 104729, "null_generation": 104759, "permutation": 104761 },
+    "sample_count": 1000,
+    "permutation_count": 10000
+  },
+  "planned_contrasts": [
+    {
+      "id": "indo-aryan-vs-controls",
+      "primary": true,
+      "target_groups": ["Indo-Aryan"],
+      "control_groups": ["non-Indo-Aryan controls"],
+      "expected_direction": "lower"
+    }
+  ],
+  "statistics": {
+    "primary_statistic": "mean_normalized_dtw_difference",
+    "correction_method": "holm",
+    "alpha": 0.05,
+    "confidence_level": 0.95
+  },
+  "outputs": {
+    "root_directory": "outputs/exploratory",
+    "scores": "scores.jsonl",
+    "quality_report": "quality-report.json",
+    "metadata": "metadata.json"
+  }
+}

--- a/experiments/protocol.md
+++ b/experiments/protocol.md
@@ -1,0 +1,102 @@
+# Frozen Research Protocol
+
+This document defines the choices represented by version 1 of the experiment,
+source-manifest, and normalized-entry schemas. It freezes analysis choices
+before language-comparison output is produced. The checked-in examples contain
+configuration and synthetic provenance only; they contain no comparison
+results.
+
+## Versioning
+
+Every instance has a `schema_version` in semantic-version form. Version 1
+validators accept `1.x.y` and reject other major versions. A major version
+changes field meaning or compatibility. Minor and patch revisions may add
+backward-compatible clarification, but released schema IDs remain stable.
+
+## Experiment Fields
+
+- `experiment_id`, `phase`, and `frozen` identify the analysis. A confirmatory
+  protocol must be frozen; an exploratory configuration may remain editable.
+- `corpus_split` names evaluation and holdout loci. Loci must be unique within
+  each partition and disjoint across partitions. Selection uses manuscript
+  metadata and folio labels only, never comparative language scores.
+- `transcription`, `mapping`, `tokenization`, and `feature_set` pin every text
+  conversion. Text is normalized to NFC. The confirmatory protocol uses one
+  predeclared mapping; exploratory work may use a declared sensitivity set.
+- `dtw` fixes the local distance, path normalization, optional window, and
+  mapping-selection policy. `null` window means unconstrained DTW.
+- `length_filters` count phoneme segments after mapping and before matching.
+- `lexicon_filters` fixes entry kinds, parts of speech, duplicate handling, and
+  whether proper names, abbreviations, or inflected forms are eligible. An
+  empty part-of-speech list means no POS restriction.
+- `randomization.seeds` provides separate non-negative seeds for balanced
+  sampling, null generation, and permutation. `sample_count` is the number of
+  sampled entries per comparison group; `permutation_count` is the number of
+  label permutations.
+- `planned_contrasts` declares exactly one primary contrast and any sensitivity
+  contrasts. `lower` means the target group is expected to have lower normalized
+  DTW distance than its controls.
+- `statistics` freezes the primary statistic, family-wise correction, alpha,
+  and confidence level. The primary statistic is target-group mean normalized
+  DTW minus control-group mean normalized DTW. The expected primary effect is
+  therefore negative. Holm correction is applied across all reported planned
+  contrasts.
+- `outputs` contains repository-relative destinations. Output artifacts must
+  record the experiment, schema, source, and software hashes when implemented.
+
+## Corpus Inclusion and Exclusion
+
+- Exclude Voynich tokens containing uncertain transcription markers, damaged
+  or unreadable glyphs, editorial alternatives, or unresolved locus metadata.
+  Do not choose between alternatives after inspecting a language score.
+- Include mapped tokens with 3 through 20 phonemes, inclusive. Count length
+  after NFC normalization, tokenization, and the pinned mapping.
+- Exclude proper names and abbreviations from the primary analysis.
+- Include lemma records only in the primary analysis. Exclude inflected forms;
+  they may appear only in a separately declared sensitivity contrast.
+- Apply no part-of-speech restriction in the primary analysis. Any future POS
+  restriction requires a new frozen protocol version.
+- Deduplicate identical normalized forms within each source. Preserve source
+  membership across sources; balanced source sampling prevents repeated forms
+  from creating source-size evidence.
+- Exclude records with missing IDs, empty IPA, invalid Unicode, unknown IPA
+  segments, or incomplete conversion. Count and report every exclusion rather
+  than silently dropping it.
+
+## Source Manifest Fields
+
+- `source_id`, `language`, and `family` identify the source and its comparison
+  grouping. `language` is a constrained BCP 47 language tag.
+- `url` and `revision` pin the upstream location and commit, tag, or release.
+- `retrieval_date` records the UTC calendar date of acquisition. `sha256` is
+  the lowercase SHA-256 digest of the unmodified raw input bytes.
+- `license` is an SPDX expression or identifier. `citation` is the complete
+  attribution text required in generated reports.
+- `parser` pins the adapter ID and version. `raw_path` and
+  `generated_artifact_path` separate acquired bytes from generated records.
+- `filters.include` and `filters.exclude` state every acquisition-time record
+  filter in human-readable, deterministic terms.
+
+## Normalized Entry Fields
+
+The normalized entry contains all fields listed in the corpus design. Nullable
+metadata fields are explicit JSON `null`, not omitted. `lemma`, `original_form`,
+`form`, and `ipa` are non-empty NFC strings. `form` is normalized orthography or
+transliteration; `original_form` preserves source spelling. `entry_kind` is one
+of `lemma`, `inflected`, `proper-name`, or `abbreviation`. `frequency` is a
+non-negative source frequency or `null` when unavailable.
+
+Construct `entry_id` as
+`source:language:percent-encoded-source-record-id`, using lowercase source and
+language IDs and RFC 3986 percent encoding for the final component. This keeps
+IDs deterministic without deriving identity from mutable definitions or IPA.
+
+## Confirmatory Decision Rule
+
+The primary contrast is Indo-Aryan versus the predeclared non-Indo-Aryan
+controls. Support requires a negative mean normalized-DTW difference whose
+confidence interval excludes zero after Holm correction, robustness to balanced
+lexicon subsampling and declared mapping/null controls, and replication on the
+untouched holdout loci. Attractive individual glosses, uncorrected rankings, or
+an effect confined to one source do not satisfy the rule. The holdout is opened
+once, only after evaluation choices and exclusions are finalized.

--- a/experiments/schemas/experiment.schema.json
+++ b/experiments/schemas/experiment.schema.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://chalcolith.github.io/enochian/schemas/experiment-1.json",
+  "title": "Enochian experiment protocol",
+  "description": "Version 1 contract for exploratory and confirmatory comparative experiments.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "experiment_id",
+    "phase",
+    "frozen",
+    "corpus_split",
+    "transcription",
+    "mapping",
+    "tokenization",
+    "feature_set",
+    "dtw",
+    "length_filters",
+    "lexicon_filters",
+    "randomization",
+    "planned_contrasts",
+    "statistics",
+    "outputs"
+  ],
+  "properties": {
+    "$schema": { "type": "string", "format": "uri-reference" },
+    "schema_version": { "type": "string", "pattern": "^1\\.[0-9]+\\.[0-9]+$" },
+    "experiment_id": { "$ref": "#/$defs/id" },
+    "phase": { "enum": ["exploratory", "confirmatory"] },
+    "frozen": { "type": "boolean" },
+    "corpus_split": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "selection_basis",
+        "selection_uses_comparative_scores",
+        "evaluation_partition",
+        "holdout_partition"
+      ],
+      "properties": {
+        "selection_basis": { "enum": ["predeclared_loci", "metadata_only_randomization"] },
+        "selection_uses_comparative_scores": { "const": false },
+        "evaluation_partition": { "$ref": "#/$defs/partition" },
+        "holdout_partition": { "$ref": "#/$defs/partition" }
+      }
+    },
+    "transcription": { "$ref": "#/$defs/versioned_component" },
+    "mapping": { "$ref": "#/$defs/versioned_component" },
+    "tokenization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["method", "version", "unicode_normalization", "uncertain_tokens"],
+      "properties": {
+        "method": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "unicode_normalization": { "const": "NFC" },
+        "uncertain_tokens": { "enum": ["exclude", "include_as_marked"] }
+      }
+    },
+    "feature_set": { "$ref": "#/$defs/versioned_component" },
+    "dtw": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["distance_metric", "normalization", "window", "mapping_selection"],
+      "properties": {
+        "distance_metric": { "enum": ["euclidean"] },
+        "normalization": { "enum": ["path_length", "none"] },
+        "window": { "type": ["integer", "null"], "minimum": 0 },
+        "mapping_selection": { "enum": ["predeclared_single", "predeclared_sensitivity_set"] }
+      }
+    },
+    "length_filters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["minimum_phonemes", "maximum_phonemes"],
+      "properties": {
+        "minimum_phonemes": { "type": "integer", "minimum": 1 },
+        "maximum_phonemes": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "lexicon_filters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entry_kinds",
+        "parts_of_speech",
+        "duplicate_forms",
+        "proper_names",
+        "abbreviations",
+        "inflected_forms"
+      ],
+      "properties": {
+        "entry_kinds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/entry_kind" }
+        },
+        "parts_of_speech": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "duplicate_forms": { "enum": ["deduplicate_within_source", "deduplicate_globally", "retain"] },
+        "proper_names": { "enum": ["exclude", "include"] },
+        "abbreviations": { "enum": ["exclude", "include"] },
+        "inflected_forms": { "enum": ["exclude", "include"] }
+      }
+    },
+    "randomization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["seeds", "sample_count", "permutation_count"],
+      "properties": {
+        "seeds": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sampling", "null_generation", "permutation"],
+          "properties": {
+            "sampling": { "type": "integer", "minimum": 0 },
+            "null_generation": { "type": "integer", "minimum": 0 },
+            "permutation": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "sample_count": { "type": "integer", "minimum": 1 },
+        "permutation_count": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "planned_contrasts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "primary", "target_groups", "control_groups", "expected_direction"],
+        "properties": {
+          "id": { "$ref": "#/$defs/id" },
+          "primary": { "type": "boolean" },
+          "target_groups": { "$ref": "#/$defs/nonempty_string_array" },
+          "control_groups": { "$ref": "#/$defs/nonempty_string_array" },
+          "expected_direction": { "enum": ["lower", "higher", "two_sided"] }
+        }
+      },
+      "contains": {
+        "type": "object",
+        "properties": { "primary": { "const": true } },
+        "required": ["primary"]
+      },
+      "minContains": 1,
+      "maxContains": 1
+    },
+    "statistics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["primary_statistic", "correction_method", "alpha", "confidence_level"],
+      "properties": {
+        "primary_statistic": { "enum": ["mean_normalized_dtw_difference"] },
+        "correction_method": { "enum": ["holm"] },
+        "alpha": { "type": "number", "exclusiveMinimum": 0, "exclusiveMaximum": 1 },
+        "confidence_level": { "type": "number", "exclusiveMinimum": 0, "exclusiveMaximum": 1 }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["root_directory", "scores", "quality_report", "metadata"],
+      "properties": {
+        "root_directory": { "$ref": "#/$defs/path" },
+        "scores": { "$ref": "#/$defs/path" },
+        "quality_report": { "$ref": "#/$defs/path" },
+        "metadata": { "$ref": "#/$defs/path" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "phase": { "const": "confirmatory" } }, "required": ["phase"] },
+      "then": { "properties": { "frozen": { "const": true } } }
+    }
+  ],
+  "$defs": {
+    "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$" },
+    "path": { "type": "string", "minLength": 1, "pattern": "^(?![A-Za-z]:|/|\\\\)" },
+    "partition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "loci"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "loci": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$" }
+        }
+      }
+    },
+    "versioned_component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "version": { "type": "string", "minLength": 1 }
+      }
+    },
+    "entry_kind": { "enum": ["lemma", "inflected", "proper-name", "abbreviation"] },
+    "nonempty_string_array": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/resources/lexicons/examples/normalized-entry.example.json
+++ b/resources/lexicons/examples/normalized-entry.example.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../schemas/normalized-entry.schema.json",
+  "schema_version": "1.0.0",
+  "entry_id": "example-lexicon:san:demo-1",
+  "source_record_id": "demo-1",
+  "language": "san",
+  "family": "Indo-European/Indo-Aryan",
+  "source": "example-lexicon",
+  "source_version": "0123456789abcdef0123456789abcdef01234567",
+  "lemma": "agni",
+  "original_form": "agni",
+  "form": "agni",
+  "entry_kind": "lemma",
+  "dialect": null,
+  "part_of_speech": "noun",
+  "definition": "fire",
+  "frequency": null,
+  "source_encoding": "Latin",
+  "ipa": "ɐɡni",
+  "unicode_normalization": "NFC",
+  "license": "CC-BY-4.0"
+}

--- a/resources/lexicons/examples/source-manifest.example.json
+++ b/resources/lexicons/examples/source-manifest.example.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../schemas/source-manifest.schema.json",
+  "schema_version": "1.0.0",
+  "source_id": "example-lexicon",
+  "language": "san",
+  "family": "Indo-European/Indo-Aryan",
+  "url": "https://example.org/lexicon.git",
+  "revision": { "kind": "commit", "value": "0123456789abcdef0123456789abcdef01234567" },
+  "retrieval_date": "2026-08-06",
+  "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "license": "CC-BY-4.0",
+  "citation": "Example Lexicon, version 1 (demonstration record; not research data).",
+  "parser": { "id": "example-parser", "version": "1.0.0" },
+  "raw_path": "resources/lexicons/raw/example-lexicon.txt",
+  "generated_artifact_path": "resources/lexicons/generated/example-lexicon.jsonl",
+  "filters": {
+    "include": ["records with a non-empty headword and pronunciation"],
+    "exclude": ["records marked as corrupt by the source"]
+  }
+}

--- a/resources/lexicons/schemas/normalized-entry.schema.json
+++ b/resources/lexicons/schemas/normalized-entry.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://chalcolith.github.io/enochian/schemas/normalized-entry-1.json",
+  "title": "Enochian normalized lexicon entry",
+  "description": "Version 1 language-neutral lexicon interchange record.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "entry_id",
+    "source_record_id",
+    "language",
+    "family",
+    "source",
+    "source_version",
+    "lemma",
+    "original_form",
+    "form",
+    "entry_kind",
+    "dialect",
+    "part_of_speech",
+    "definition",
+    "frequency",
+    "source_encoding",
+    "ipa",
+    "unicode_normalization",
+    "license"
+  ],
+  "properties": {
+    "$schema": { "type": "string", "format": "uri-reference" },
+    "schema_version": { "type": "string", "pattern": "^1\\.[0-9]+\\.[0-9]+$" },
+    "entry_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*:[a-z]{2,3}(?:-[A-Za-z0-9]+)*:[A-Za-z0-9._~%-]+$"
+    },
+    "source_record_id": { "type": "string", "minLength": 1 },
+    "language": { "$ref": "#/$defs/language_code" },
+    "family": { "type": "string", "minLength": 1 },
+    "source": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$" },
+    "source_version": { "type": "string", "minLength": 1 },
+    "lemma": { "type": "string", "minLength": 1 },
+    "original_form": { "type": "string", "minLength": 1 },
+    "form": { "type": "string", "minLength": 1 },
+    "entry_kind": { "enum": ["lemma", "inflected", "proper-name", "abbreviation"] },
+    "dialect": { "type": ["string", "null"], "minLength": 1 },
+    "part_of_speech": { "type": ["string", "null"], "minLength": 1 },
+    "definition": { "type": ["string", "null"] },
+    "frequency": { "type": ["number", "null"], "minimum": 0 },
+    "source_encoding": { "type": "string", "minLength": 1 },
+    "ipa": { "type": "string", "minLength": 1 },
+    "unicode_normalization": { "const": "NFC" },
+    "license": { "type": "string", "minLength": 1, "pattern": "^[A-Za-z0-9.+() -]+$" }
+  },
+  "$defs": {
+    "language_code": {
+      "type": "string",
+      "pattern": "^[a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-(?:[A-Z]{2}|[0-9]{3}))?$"
+    }
+  }
+}

--- a/resources/lexicons/schemas/source-manifest.schema.json
+++ b/resources/lexicons/schemas/source-manifest.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://chalcolith.github.io/enochian/schemas/source-manifest-1.json",
+  "title": "Enochian lexicon source manifest",
+  "description": "Version 1 provenance contract for an acquired lexicon source.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "source_id",
+    "language",
+    "family",
+    "url",
+    "revision",
+    "retrieval_date",
+    "sha256",
+    "license",
+    "citation",
+    "parser",
+    "raw_path",
+    "generated_artifact_path",
+    "filters"
+  ],
+  "properties": {
+    "$schema": { "type": "string", "format": "uri-reference" },
+    "schema_version": { "type": "string", "pattern": "^1\\.[0-9]+\\.[0-9]+$" },
+    "source_id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$" },
+    "language": { "$ref": "#/$defs/language_code" },
+    "family": { "type": "string", "minLength": 1 },
+    "url": { "type": "string", "format": "uri" },
+    "revision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "value"],
+      "properties": {
+        "kind": { "enum": ["commit", "tag", "release"] },
+        "value": { "type": "string", "minLength": 1 }
+      }
+    },
+    "retrieval_date": { "type": "string", "format": "date" },
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "license": { "type": "string", "minLength": 1, "pattern": "^[A-Za-z0-9.+() -]+$" },
+    "citation": { "type": "string", "minLength": 1 },
+    "parser": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$" },
+        "version": { "type": "string", "minLength": 1 }
+      }
+    },
+    "raw_path": { "$ref": "#/$defs/path" },
+    "generated_artifact_path": { "$ref": "#/$defs/path" },
+    "filters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["include", "exclude"],
+      "properties": {
+        "include": { "$ref": "#/$defs/string_array" },
+        "exclude": { "$ref": "#/$defs/string_array" }
+      }
+    }
+  },
+  "$defs": {
+    "language_code": {
+      "type": "string",
+      "pattern": "^[a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-(?:[A-Z]{2}|[0-9]{3}))?$"
+    },
+    "path": { "type": "string", "minLength": 1, "pattern": "^(?![A-Za-z]:|/|\\\\)" },
+    "string_array": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/source/Directory.Packages.props
+++ b/source/Directory.Packages.props
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageVersion Include="JsonSchema.Net" Version="9.4.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />

--- a/source/Enochian.UnitTests/Enochian.UnitTests.csproj
+++ b/source/Enochian.UnitTests/Enochian.UnitTests.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="MSTest.Sdk">
   <ItemGroup>
+    <PackageReference Include="JsonSchema.Net" />
     <ProjectReference Include="..\Enochian\Enochian.csproj" />
   </ItemGroup>
 </Project>

--- a/source/Enochian.UnitTests/Fixtures/Schemas/invalid-language-code.json
+++ b/source/Enochian.UnitTests/Fixtures/Schemas/invalid-language-code.json
@@ -1,0 +1,5 @@
+{
+  "schema": "source-manifest",
+  "base": "resources/lexicons/examples/source-manifest.example.json",
+  "patch": { "language": "Sanskrit" }
+}

--- a/source/Enochian.UnitTests/Fixtures/Schemas/missing-checksum.json
+++ b/source/Enochian.UnitTests/Fixtures/Schemas/missing-checksum.json
@@ -1,0 +1,5 @@
+{
+  "schema": "source-manifest",
+  "base": "resources/lexicons/examples/source-manifest.example.json",
+  "patch": { "sha256": null }
+}

--- a/source/Enochian.UnitTests/Fixtures/Schemas/missing-version.json
+++ b/source/Enochian.UnitTests/Fixtures/Schemas/missing-version.json
@@ -1,0 +1,5 @@
+{
+  "schema": "experiment",
+  "base": "experiments/exploratory.example.json",
+  "patch": { "schema_version": null }
+}

--- a/source/Enochian.UnitTests/Fixtures/Schemas/overlapping-partitions.json
+++ b/source/Enochian.UnitTests/Fixtures/Schemas/overlapping-partitions.json
@@ -1,0 +1,9 @@
+{
+  "schema": "experiment",
+  "base": "experiments/confirmatory.protocol.json",
+  "patch": {
+    "corpus_split": {
+      "holdout_partition": { "loci": ["f1r", "f3v", "f4r", "f4v"] }
+    }
+  }
+}

--- a/source/Enochian.UnitTests/Fixtures/Schemas/unknown-entry-kind.json
+++ b/source/Enochian.UnitTests/Fixtures/Schemas/unknown-entry-kind.json
@@ -1,0 +1,5 @@
+{
+  "schema": "normalized-entry",
+  "base": "resources/lexicons/examples/normalized-entry.example.json",
+  "patch": { "entry_kind": "phrase" }
+}

--- a/source/Enochian.UnitTests/Fixtures/Schemas/unknown-major-version.json
+++ b/source/Enochian.UnitTests/Fixtures/Schemas/unknown-major-version.json
@@ -1,0 +1,5 @@
+{
+  "schema": "experiment",
+  "base": "experiments/exploratory.example.json",
+  "patch": { "schema_version": "2.0.0" }
+}

--- a/source/Enochian.UnitTests/Fixtures/Schemas/unspecified-random-seed.json
+++ b/source/Enochian.UnitTests/Fixtures/Schemas/unspecified-random-seed.json
@@ -1,0 +1,5 @@
+{
+  "schema": "experiment",
+  "base": "experiments/confirmatory.protocol.json",
+  "patch": { "randomization": { "seeds": { "permutation": null } } }
+}

--- a/source/Enochian.UnitTests/SchemaTests.cs
+++ b/source/Enochian.UnitTests/SchemaTests.cs
@@ -1,0 +1,208 @@
+using Json.Schema;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Enochian.UnitTests;
+
+[TestClass]
+public class SchemaTests
+{
+    private static readonly string RepositoryRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "../../../../.."));
+    private static readonly JsonSchema ExperimentSchema = LoadSchema("experiments/schemas/experiment.schema.json");
+    private static readonly JsonSchema SourceManifestSchema =
+        LoadSchema("resources/lexicons/schemas/source-manifest.schema.json");
+    private static readonly JsonSchema NormalizedEntrySchema =
+        LoadSchema("resources/lexicons/schemas/normalized-entry.schema.json");
+
+    [TestMethod]
+    public void ValidExamplesConformToSchemas()
+    {
+        AssertValid(ExperimentSchema, "experiments/exploratory.example.json");
+        AssertValid(ExperimentSchema, "experiments/confirmatory.protocol.json");
+        AssertValid(SourceManifestSchema, "resources/lexicons/examples/source-manifest.example.json");
+        AssertValid(NormalizedEntrySchema, "resources/lexicons/examples/normalized-entry.example.json");
+    }
+
+    [TestMethod]
+    [DataRow("missing-version.json")]
+    [DataRow("missing-checksum.json")]
+    [DataRow("unknown-entry-kind.json")]
+    [DataRow("invalid-language-code.json")]
+    [DataRow("unspecified-random-seed.json")]
+    [DataRow("overlapping-partitions.json")]
+    [DataRow("unknown-major-version.json")]
+    public void InvalidFixturesAreRejected(string fixtureName)
+    {
+        var (schemaName, instance) = LoadInvalidFixture(fixtureName);
+
+        Assert.IsFalse(IsValid(schemaName, instance), $"{fixtureName} unexpectedly passed validation.");
+    }
+
+    [TestMethod]
+    public void UnknownMajorVersionReportsSupportedVersion()
+    {
+        var (_, instance) = LoadInvalidFixture("unknown-major-version.json");
+
+        var error = GetVersionError(instance);
+
+        Assert.AreEqual("Unsupported schema_version major 2; supported major is 1.", error);
+    }
+
+    [TestMethod]
+    public void ExampleDocumentsRoundTripWithoutFieldLoss()
+    {
+        var paths = new[]
+        {
+            "experiments/exploratory.example.json",
+            "experiments/confirmatory.protocol.json",
+            "resources/lexicons/examples/source-manifest.example.json",
+            "resources/lexicons/examples/normalized-entry.example.json",
+        };
+
+        foreach (var path in paths)
+        {
+            var original = LoadObject(path);
+            var roundTripped = JsonNode.Parse(original.ToJsonString())?.AsObject();
+
+            Assert.IsNotNull(roundTripped, $"Unable to deserialize round-tripped {path}.");
+            Assert.IsTrue(JsonNode.DeepEquals(original, roundTripped), $"Round trip changed fields in {path}.");
+        }
+    }
+
+    [TestMethod]
+    public void NormalizedEntryUsesNfcAndDeterministicId()
+    {
+        var entry = LoadObject("resources/lexicons/examples/normalized-entry.example.json");
+        var stringFields = new[] { "lemma", "original_form", "form", "ipa" };
+
+        foreach (var field in stringFields)
+        {
+            var value = entry[field]?.GetValue<string>()
+                ?? throw new AssertFailedException($"Missing {field}.");
+            Assert.IsTrue(value.IsNormalized(NormalizationForm.FormC), $"{field} is not NFC.");
+        }
+
+        var source = entry["source"]?.GetValue<string>();
+        var language = entry["language"]?.GetValue<string>();
+        var sourceRecordId = entry["source_record_id"]?.GetValue<string>();
+        var expectedId = $"{source}:{language}:{Uri.EscapeDataString(sourceRecordId ?? string.Empty)}";
+        Assert.AreEqual(expectedId, entry["entry_id"]?.GetValue<string>());
+    }
+
+    private static void AssertValid(JsonSchema schema, string instancePath)
+    {
+        using var instance = JsonDocument.Parse(File.ReadAllText(GetPath(instancePath)));
+        var result = schema.Evaluate(instance.RootElement,
+            new EvaluationOptions { OutputFormat = OutputFormat.List });
+
+        Assert.IsTrue(result.IsValid, $"{instancePath} does not conform to its schema.");
+    }
+
+    private static bool IsValid(string schemaName, JsonObject instance)
+    {
+        var schema = schemaName switch
+        {
+            "experiment" => ExperimentSchema,
+            "source-manifest" => SourceManifestSchema,
+            "normalized-entry" => NormalizedEntrySchema,
+            _ => throw new AssertFailedException($"Unknown fixture schema {schemaName}."),
+        };
+        using var document = JsonDocument.Parse(instance.ToJsonString());
+        var schemaResult = schema.Evaluate(document.RootElement);
+        if (!schemaResult.IsValid || GetVersionError(instance) != null)
+        {
+            return false;
+        }
+
+        return schemaName != "experiment" || HasDisjointPartitions(instance);
+    }
+
+    private static string? GetVersionError(JsonObject instance)
+    {
+        if (instance["schema_version"] is not JsonValue versionNode ||
+            !versionNode.TryGetValue<string>(out var version))
+        {
+            return "schema_version is required.";
+        }
+
+        var majorText = version.Split('.', 2)[0];
+        return int.TryParse(majorText, out var major) && major == 1
+            ? null
+            : $"Unsupported schema_version major {majorText}; supported major is 1.";
+    }
+
+    private static bool HasDisjointPartitions(JsonObject instance)
+    {
+        var split = instance["corpus_split"]?.AsObject()
+            ?? throw new AssertFailedException("Experiment has no corpus_split.");
+        var evaluation = split["evaluation_partition"]?["loci"]?.AsArray()
+            .Select(node => node?.GetValue<string>())
+            .Where(value => value != null)
+            .Cast<string>()
+            .ToHashSet(StringComparer.Ordinal) ?? [];
+        var holdout = split["holdout_partition"]?["loci"]?.AsArray()
+            .Select(node => node?.GetValue<string>())
+            .Where(value => value != null)
+            .Cast<string>() ?? [];
+
+        return !holdout.Any(evaluation.Contains);
+    }
+
+    private static (string SchemaName, JsonObject Instance) LoadInvalidFixture(string fixtureName)
+    {
+        var fixture = LoadObject($"source/Enochian.UnitTests/Fixtures/Schemas/{fixtureName}");
+        var schemaName = fixture["schema"]?.GetValue<string>()
+            ?? throw new AssertFailedException($"Fixture {fixtureName} has no schema.");
+        var basePath = fixture["base"]?.GetValue<string>()
+            ?? throw new AssertFailedException($"Fixture {fixtureName} has no base.");
+        var patch = fixture["patch"]?.AsObject()
+            ?? throw new AssertFailedException($"Fixture {fixtureName} has no patch.");
+        var instance = LoadObject(basePath);
+
+        ApplyMergePatch(instance, patch);
+        return (schemaName, instance);
+    }
+
+    private static void ApplyMergePatch(JsonObject target, JsonObject patch)
+    {
+        foreach (var property in patch)
+        {
+            if (property.Value == null)
+            {
+                _ = target.Remove(property.Key);
+            }
+            else if (property.Value is JsonObject objectPatch)
+            {
+                if (target[property.Key] is not JsonObject child)
+                {
+                    child = [];
+                    target[property.Key] = child;
+                }
+
+                ApplyMergePatch(child, objectPatch);
+            }
+            else
+            {
+                target[property.Key] = property.Value.DeepClone();
+            }
+        }
+    }
+
+    private static JsonSchema LoadSchema(string schemaPath)
+    {
+        return JsonSchema.FromText(File.ReadAllText(GetPath(schemaPath)));
+    }
+
+    private static JsonObject LoadObject(string relativePath)
+    {
+        return JsonNode.Parse(File.ReadAllText(GetPath(relativePath)))?.AsObject()
+            ?? throw new AssertFailedException($"Unable to parse {relativePath}.");
+    }
+
+    private static string GetPath(string relativePath)
+    {
+        return Path.Combine(RepositoryRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+    }
+}

--- a/source/Enochian.slnx
+++ b/source/Enochian.slnx
@@ -4,6 +4,14 @@
     <File Path="../LICENSE" />
     <File Path="../README.md" />
   </Folder>
+  <Folder Name="/Solution Items/experiments/">
+    <File Path="../experiments/confirmatory.protocol.json" />
+    <File Path="../experiments/exploratory.example.json" />
+    <File Path="../experiments/protocol.md" />
+  </Folder>
+  <Folder Name="/Solution Items/experiments/schemas/">
+    <File Path="../experiments/schemas/experiment.schema.json" />
+  </Folder>
   <Folder Name="/Solution Items/reports/">
     <File Path="../reports/enochian.css" />
   </Folder>
@@ -17,6 +25,14 @@
     <File Path="../resources/encodings/romlex.json" />
     <File Path="../resources/encodings/slp1.json" />
     <File Path="../resources/encodings/vogt.json" />
+  </Folder>
+  <Folder Name="/Solution Items/resources/lexicons/examples/">
+    <File Path="../resources/lexicons/examples/normalized-entry.example.json" />
+    <File Path="../resources/lexicons/examples/source-manifest.example.json" />
+  </Folder>
+  <Folder Name="/Solution Items/resources/lexicons/schemas/">
+    <File Path="../resources/lexicons/schemas/normalized-entry.schema.json" />
+    <File Path="../resources/lexicons/schemas/source-manifest.schema.json" />
   </Folder>
   <Folder Name="/Solution Items/samples/">
     <File Path="../samples/english_test.json" />


### PR DESCRIPTION
## Summary

- define stable version 1 JSON Schemas for experiment protocols, source manifests, and normalized lexicon entries
- check in result-free exploratory and confirmatory configurations with disjoint evaluation and holdout loci
- freeze corpus inclusion/exclusion rules, DTW and randomization settings, the primary Indo-Aryan contrast, Holm correction, and the confirmatory decision rule
- document provenance, Unicode normalization, nullability, entry kinds, and deterministic normalized-entry ID construction
- add valid examples and negative fixtures for every M0-01 failure case
- add schema, version, partition, NFC, deterministic-ID, and lossless round-trip tests

## Frozen protocol safeguards

- partition selection explicitly forbids use of comparative language scores
- confirmatory protocols must be marked frozen
- evaluation and holdout loci are checked for overlap
- unknown schema major versions fail with a supported-version message
- no language-comparison output is included

## Validation

- `dotnet build Enochian.slnx`: all six projects passed
- `dotnet test Enochian.slnx`: 21 passed, 0 failed, 0 skipped
- formatting verification passed excluding only the documented `CS1591` baseline